### PR TITLE
upgpkg: salt 3007.2

### DIFF
--- a/salt/PKGBUILD
+++ b/salt/PKGBUILD
@@ -7,8 +7,8 @@
 # Contributor: zer0def <zer0def@github>
 
 pkgname=salt
-pkgver=3007.1
-pkgrel=7
+pkgver=3007.2
+pkgrel=1
 pkgdesc='Portable, distributed, remote execution and configuration management system'
 arch=('any')
 url='https://saltproject.io/'
@@ -69,7 +69,7 @@ source=(
   salt-call
 )
 sha256sums=(
-  'b933ac4cb3e4b1118b46dada55c9cc6bdc6f0f94b4c92877aec44b25c6a28c9a'
+  '76dfd8e43db646fb357ba52b45394008182549b6a5584688ed452c48c9d112ec'
   'abecc3c1be124c4afffaaeb3ba32b60dfee8ba6dc32189edfa2ad154ecb7a215'
   'SKIP'
   'SKIP'
@@ -107,7 +107,7 @@ package() {
   for _svc in salt-master.service salt-syndic.service salt-minion.service salt-api.service; do
     install -v -Dm644 pkg/common/$_svc "$pkgdir/usr/lib/systemd/system/$_svc"
   done
-  install -v -Dm644 pkg/common/salt.bash "$pkgdir/usr/share/bash-completion/completions/salt"
+  install -v -Dm644 pkg/rpm/salt.bash "$pkgdir/usr/share/bash-completion/completions/salt"
   install -v -Dm644 pkg/common/salt.zsh "$pkgdir/usr/share/zsh/site-functions/_salt"
   install -v -Dm644 -t "$pkgdir/usr/share/fish/vendor_completions.d" pkg/common/fish-completions/*
 }

--- a/salt/contextvars.patch
+++ b/salt/contextvars.patch
@@ -1,22 +1,8 @@
-Index: salt-3007.1/requirements/base.txt
+Index: salt-3007.2/requirements/base.txt
 ===================================================================
---- salt-3007.1.orig/requirements/base.txt	2024-11-06 20:25:51.898374912 +0100
-+++ salt-3007.1/requirements/base.txt	2024-11-06 20:26:23.586354279 +0100
-@@ -15,7 +15,6 @@ aiohttp>=3.9.0
- 
- # We need contextvars for salt-ssh.
- # Even on python versions which ships with contextvars in the standard library!
+--- salt-3007.2.orig/requirements/base.txt      2025-05-13 11:24:53.000000000 +0200
++++ salt-3007.2/requirements/base.txt   2025-05-14 22:14:08.434749910 +0200
+@@ -51,3 +51,2 @@ croniter>=0.3.0,!=0.3.22; sys_platform !
+ # We need contextvars for salt-ssh
 -contextvars
- 
- setproctitle>=1.2.3
- timelib>=0.2.5
-Index: salt-3007.1/requirements/zeromq.txt
-===================================================================
---- salt-3007.1.orig/requirements/zeromq.txt	2024-11-06 20:25:51.899374912 +0100
-+++ salt-3007.1/requirements/zeromq.txt	2024-11-06 20:27:44.898301325 +0100
-@@ -1,4 +1,4 @@
- -r base.txt
- -r crypto.txt
- 
--pyzmq>=25.1.2
-+pyzmq>=25.1.1
+ cryptography>=42.0.0


### PR DESCRIPTION
In case you (or anyone) is interested I got this to build with the new release. I have tested that the built package runs a salt-master, and that it manages to ping salt-3007-1 and salt-3007-2 minions.

Except that, I have not managed to test much. salt-3007 have been giving me all sorts of problems, and this did not seem to resolve any ZeroMQ connection troubles.

BTW, I have no idea what upgpkg is, I just added a commit message like your previous ones