### PR TITLE
Fix build with FFmpeg 8.

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -25,9 +25,11 @@ pkgbase = python-torchvision-rocm
 	source = vision-0.23.0.tar.gz::https://github.com/pytorch/vision/archive/v0.23.0.tar.gz
 	source = pytorch-vision-8408.patch
 	source = torchvision-0_17_1-fix-build.patch
+	source = ffmpeg-8.patch
 	sha256sums = db5a91569e5eb4a3b02e9eaad6080335f5ae3824890a697f5618541999f04027
 	sha256sums = d14ce08f7d1929fff746d7fc7b80b3065a5d7111ab08b5a5e73b44e77bf1b56f
 	sha256sums = ed715ca202d2b010c50414e370ebc0492f0f42b298a8e6e03f9fe80b7ce60331
+	sha256sums = 1c466d4ae0874a8ab6518cb3b0c7747f43060fb6803352ac9e13f2b5ecae1931
 
 pkgname = torchvision-rocm
 	pkgdesc = Datasets, transforms, and models specific to computer vision (C++ library only, with ROCM support)

--- a/python-torchvision-rocm/PKGBUILD
+++ b/python-torchvision-rocm/PKGBUILD
@@ -44,16 +44,20 @@ source=(
 	"${_pkgname}-${pkgver}.tar.gz::https://github.com/pytorch/vision/archive/v${pkgver}.tar.gz"
 	"pytorch-vision-8408.patch"
 	"torchvision-0_17_1-fix-build.patch"
+	"ffmpeg-8.patch"
 )
 sha256sums=('db5a91569e5eb4a3b02e9eaad6080335f5ae3824890a697f5618541999f04027'
             'd14ce08f7d1929fff746d7fc7b80b3065a5d7111ab08b5a5e73b44e77bf1b56f'
-            'ed715ca202d2b010c50414e370ebc0492f0f42b298a8e6e03f9fe80b7ce60331')
-
+            'ed715ca202d2b010c50414e370ebc0492f0f42b298a8e6e03f9fe80b7ce60331'
+            '1c466d4ae0874a8ab6518cb3b0c7747f43060fb6803352ac9e13f2b5ecae1931')
 prepare() {
 	cd "${srcdir}/${_pkgname}-${pkgver}"
 
 	# https://github.com/pytorch/vision/issues/8307
 	patch -N -i "${srcdir}"/torchvision-0_17_1-fix-build.patch
+
+        # Fix build with ffmpeg 8
+        patch -p1 -i "${srcdir}"/ffmpeg-8.patch
 }
 
 build() {

--- a/python-torchvision-rocm/ffmpeg-8.patch
+++ b/python-torchvision-rocm/ffmpeg-8.patch
@@ -1,0 +1,12 @@
+diff -rup vision-0.23.0.orig/torchvision/csrc/io/decoder/video_stream.cpp vision-0.23.0/torchvision/csrc/io/decoder/video_stream.cpp
+--- vision-0.23.0.orig/torchvision/csrc/io/decoder/video_stream.cpp	2025-09-29 09:28:57.678370404 -0400
++++ vision-0.23.0/torchvision/csrc/io/decoder/video_stream.cpp	2025-09-29 09:29:51.544541164 -0400
+@@ -122,7 +122,7 @@ int VideoStream::copyFrameBytes(ByteStor
+ void VideoStream::setHeader(DecoderHeader* header, bool flush) {
+   Stream::setHeader(header, flush);
+   if (!flush) { // no frames for video flush
+-    header->keyFrame = frame_->key_frame;
++    header->keyFrame = !!(frame_->flags & AV_FRAME_FLAG_KEY);
+     header->fps = av_q2d(av_guess_frame_rate(
+         inputCtx_, inputCtx_->streams[format_.stream], nullptr));
+   }


### PR DESCRIPTION
The build is broken since FFmpeg 8.

To fix this I have ported a patch from the CUDA torchvsion package:
https://gitlab.archlinux.org/archlinux/packaging/packages/torchvision/-/commit/0a7889449ae504a52c92b1a6596e9a709aa861aa