### PR TITLE
librefang-git: refresh local inference patches for current upstream

### DIFF
--- a/librefang-git/.SRCINFO
+++ b/librefang-git/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = librefang-git
 	pkgdesc = LibreFang is an open-source Agent Operating System written in Rust. (GIT version with patches for local STT,TTS,IMAGE support)
-	pkgver = 2026.6.29.r9.g83ee2627b
+	pkgver = 2026.7.27.r13.g1b9518fd1
 	pkgrel = 1
 	url = https://github.com/librefang/librefang
 	arch = x86_64
@@ -36,9 +36,9 @@ pkgbase = librefang-git
 	sha256sums = cf026330b3d4c3c708bd079b15401731e1afef4f3e780c4ad286ad0d961a6d5c
 	sha256sums = a640db0197d001c5ae9348d57cda8092e2c8170fa27ced98d5546557fadb6d17
 	sha256sums = 1ddb18ffdd4c4131bf9a35debfb21a61aeda8ca1be90829e0e1b10d7bf19b975
-	sha256sums = 0e4ccc9ec9d34b0c765f1fac33a8e22949ef19fc05148fe18c1dad78718dcbc4
-	sha256sums = 8d8e5722dcdbe7821e9375018076cebfcc5d30a7b8e646623714190dd0d1383e
-	sha256sums = 6226943a917e31ea998fdf9626a8d67aff17541491b62c58ce12c4f679c6d187
+	sha256sums = aa2df1c379d02a52bf4072f3de2f6c3be0512fc3efcbb141320ba19d8fc3ca46
+	sha256sums = c4fccf730140e3cbe1c694b6f4f3b94c47b998ba76262ce50c63f578822d5918
+	sha256sums = 673dc14c22aa89457a2e1684bf075b7e0ae5ecc520830529b6edcfac1e68246b
 	sha256sums = 6fa3cb22d68b37cdc9605cc5c02c9095ea4ce47466e415c01dc54c7f7e81bb6a
 
 pkgname = librefang-git

--- a/librefang-git/PKGBUILD
+++ b/librefang-git/PKGBUILD
@@ -81,10 +81,19 @@ build() {
     export CARGO_PROFILE_RELEASE_LTO=false
     cargo build --frozen --release --bin librefang --bin librefang-desktop
 
-    # Build Node.js whatsapp-gateway
+    # Build Node.js whatsapp-gateway.
+    # baileys depends on libsignal from git. npm >= 12 defaults allow-git to
+    # "none" and refuses to fetch it; --allow-git=root is not enough because
+    # libsignal is transitive, not in the gateway's own package.json. The
+    # lockfile also resolves it over ssh, which has no credentials here, so
+    # rewrite ssh to https (HOME is confined to ${srcdir}/.home above).
     local _gwdir="${srcdir}/${pkgbase}/packages/whatsapp-gateway"
     cd "${_gwdir}"
-    npm install --ignore-scripts --omit=dev --legacy-peer-deps
+    # makepkg pins GIT_CONFIG_GLOBAL to /dev/null, so redirect it at a writable
+    # path before configuring the rewrite.
+    export GIT_CONFIG_GLOBAL="${srcdir}/.home/.gitconfig"
+    git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"
+    npm install --ignore-scripts --omit=dev --legacy-peer-deps --allow-git=all
     # Copy system node-addon-api for compiling sharp/better-sqlite3 if needed
     cp -r /usr/lib/node_modules/node-addon-api "${_gwdir}/node_modules/node-addon-api"
 

--- a/librefang-git/PKGBUILD
+++ b/librefang-git/PKGBUILD
@@ -2,7 +2,7 @@
 # Contributor: SteamedFish <steamedfish@hotmail.com>
 pkgbase=librefang-git
 pkgname=("librefang-git" "librefang-desktop-git" "librefang-whatsapp-gateway-git")
-pkgver=2026.6.29.r9.g83ee2627b
+pkgver=2026.7.27.r13.g1b9518fd1
 pkgrel=1
 pkgdesc='LibreFang is an open-source Agent Operating System written in Rust. (GIT version with patches for local STT,TTS,IMAGE support) '
 arch=('x86_64' 'aarch64')
@@ -27,9 +27,9 @@ sha256sums=('SKIP'
             'cf026330b3d4c3c708bd079b15401731e1afef4f3e780c4ad286ad0d961a6d5c'
             'a640db0197d001c5ae9348d57cda8092e2c8170fa27ced98d5546557fadb6d17'
             '1ddb18ffdd4c4131bf9a35debfb21a61aeda8ca1be90829e0e1b10d7bf19b975'
-            '0e4ccc9ec9d34b0c765f1fac33a8e22949ef19fc05148fe18c1dad78718dcbc4'
-            '8d8e5722dcdbe7821e9375018076cebfcc5d30a7b8e646623714190dd0d1383e'
-            '6226943a917e31ea998fdf9626a8d67aff17541491b62c58ce12c4f679c6d187'
+            'aa2df1c379d02a52bf4072f3de2f6c3be0512fc3efcbb141320ba19d8fc3ca46'
+            'c4fccf730140e3cbe1c694b6f4f3b94c47b998ba76262ce50c63f578822d5918'
+            '673dc14c22aa89457a2e1684bf075b7e0ae5ecc520830529b6edcfac1e68246b'
             '6fa3cb22d68b37cdc9605cc5c02c9095ea4ce47466e415c01dc54c7f7e81bb6a')
 
 pkgver() {

--- a/librefang-git/feature-local-image.patch
+++ b/librefang-git/feature-local-image.patch
@@ -1,18 +1,18 @@
 diff --git a/crates/librefang-runtime-media/src/media_understanding.rs b/crates/librefang-runtime-media/src/media_understanding.rs
-index 887275d9a..321ef66ef 100644
+index fbb83406..e5579202 100644
 --- a/crates/librefang-runtime-media/src/media_understanding.rs
 +++ b/crates/librefang-runtime-media/src/media_understanding.rs
-@@ -113,7 +113,8 @@ impl MediaEngine {
-         let description = match provider {
-             "anthropic" => anthropic_describe_image(model, &image_bytes, mime_type).await?,
-             "openai" | "groq" => {
--                let (api_url, api_key) = openai_vision_provider_config(provider)?;
-+                let custom_url = self.config.image_base_url.as_deref();
-+                let (api_url, api_key) = openai_vision_provider_config(provider, custom_url)?;
-                 openai_describe_image(&api_url, &api_key, model, &image_bytes, mime_type).await?
-             }
-             "gemini" => gemini_describe_image(model, &image_bytes, mime_type).await?,
-@@ -394,14 +395,21 @@ fn detect_vision_provider() -> Option<&'static str> {
+@@ -151,7 +151,8 @@ impl MediaEngine {
+             match provider {
+                 "anthropic" => anthropic_describe_image(model, &image_bytes, mime_type).await,
+                 "openai" | "groq" => {
+-                    let (api_url, api_key) = openai_vision_provider_config(provider)?;
++                    let custom_url = self.config.image_base_url.as_deref();
++                    let (api_url, api_key) = openai_vision_provider_config(provider, custom_url)?;
+                     openai_describe_image(&api_url, &api_key, model, &image_bytes, mime_type).await
+                 }
+                 "gemini" => gemini_describe_image(model, &image_bytes, mime_type).await,
+@@ -460,14 +461,21 @@ fn detect_vision_provider() -> Option<&'static str> {
  // ── Vision provider helpers ───────────────────────────────────────────────
  
  /// Resolve OpenAI-compatible vision API URL and key for a provider.
@@ -37,7 +37,7 @@ index 887275d9a..321ef66ef 100644
              std::env::var("GROQ_API_KEY").map_err(|_| "GROQ_API_KEY not set")?,
          )),
          other => Err(format!(
-@@ -1385,19 +1393,35 @@ mod tests {
+@@ -1500,19 +1508,35 @@ mod tests {
      #[test]
      fn openai_vision_provider_config_resolves_known_providers() {
          // With no env set these return Err("not set"), but the URL/structure is stable
@@ -77,7 +77,7 @@ index 887275d9a..321ef66ef 100644
  
      #[test]
 diff --git a/crates/librefang-types/src/media.rs b/crates/librefang-types/src/media.rs
-index 4223a6058..c58d2983d 100644
+index 7f86b88f..ee149af5 100644
 --- a/crates/librefang-types/src/media.rs
 +++ b/crates/librefang-types/src/media.rs
 @@ -117,6 +117,8 @@ pub struct MediaConfig {
@@ -97,7 +97,7 @@ index 4223a6058..c58d2983d 100644
              audio_provider: None,
              audio_model: None,
              audio_base_url: None,
-@@ -792,6 +795,7 @@ mod tests {
+@@ -930,6 +933,7 @@ mod tests {
          assert_eq!(config.max_concurrency, 2);
          assert!(config.image_provider.is_none());
          assert!(config.image_model.is_none());

--- a/librefang-git/feature-local-stt.patch
+++ b/librefang-git/feature-local-stt.patch
@@ -1,18 +1,18 @@
 diff --git a/crates/librefang-runtime-media/src/media_understanding.rs b/crates/librefang-runtime-media/src/media_understanding.rs
-index da809fd77..887275d9a 100644
+index 43a9a9a4..fbb83406 100644
 --- a/crates/librefang-runtime-media/src/media_understanding.rs
 +++ b/crates/librefang-runtime-media/src/media_understanding.rs
-@@ -257,7 +257,8 @@ impl MediaEngine {
-         let transcription = match provider {
-             // Whisper-compatible providers (OpenAI multipart protocol)
-             "groq" | "openai" | "minimax" | "fireworks" | "together" | "siliconflow" => {
--                let (api_url, api_key) = whisper_provider_config(provider)?;
-+                let custom_url = self.config.audio_base_url.as_deref();
-+                let (api_url, api_key) = whisper_provider_config(provider, custom_url)?;
-                 whisper_transcribe(&api_url, &api_key, model, audio_bytes, &filename, &mime).await?
-             }
-             // Gemini — multimodal content generation with audio input
-@@ -626,32 +627,44 @@ async fn gemini_describe_image(
+@@ -310,7 +310,8 @@ impl MediaEngine {
+             match provider {
+                 // Whisper-compatible providers (OpenAI multipart protocol)
+                 "groq" | "openai" | "minimax" | "fireworks" | "together" | "siliconflow" => {
+-                    let (api_url, api_key) = whisper_provider_config(provider)?;
++                    let custom_url = self.config.audio_base_url.as_deref();
++                    let (api_url, api_key) = whisper_provider_config(provider, custom_url)?;
+                     whisper_transcribe(&api_url, &api_key, model, audio_bytes, &filename, &mime)
+                         .await
+                 }
+@@ -692,32 +693,44 @@ async fn gemini_describe_image(
  // ── STT provider helpers ──────────────────────────────────────────────
  
  /// Resolve Whisper-compatible API URL and key for a provider.
@@ -65,7 +65,7 @@ index da809fd77..887275d9a 100644
          )),
          other => Err(format!("Unknown Whisper-compatible provider: {other}")),
 diff --git a/crates/librefang-types/src/media.rs b/crates/librefang-types/src/media.rs
-index db7fb8411..4223a6058 100644
+index bf3387c1..7f86b88f 100644
 --- a/crates/librefang-types/src/media.rs
 +++ b/crates/librefang-types/src/media.rs
 @@ -124,6 +124,8 @@ pub struct MediaConfig {

--- a/librefang-git/feature-local-tts.patch
+++ b/librefang-git/feature-local-tts.patch
@@ -1,8 +1,8 @@
 diff --git a/crates/librefang-runtime/src/tts.rs b/crates/librefang-runtime/src/tts.rs
-index a50a6fce5..b1ba51eb9 100644
+index 51fd35d8..4dbc56a7 100644
 --- a/crates/librefang-runtime/src/tts.rs
 +++ b/crates/librefang-runtime/src/tts.rs
-@@ -124,9 +124,13 @@ impl TtsEngine {
+@@ -148,9 +148,13 @@ impl TtsEngine {
              "speed": self.config.openai.speed,
          });
  
@@ -18,10 +18,10 @@ index a50a6fce5..b1ba51eb9 100644
              .header("Content-Type", "application/json")
              .json(&body)
 diff --git a/crates/librefang-types/src/config/types.rs b/crates/librefang-types/src/config/types.rs
-index 1235e6254..5c8c50eab 100644
+index 8af21dbc..9d590abc 100644
 --- a/crates/librefang-types/src/config/types.rs
 +++ b/crates/librefang-types/src/config/types.rs
-@@ -1348,6 +1348,8 @@ pub struct TtsOpenAiConfig {
+@@ -1371,6 +1371,8 @@ pub struct TtsOpenAiConfig {
      pub format: String,
      /// Speed: 0.25 to 4.0. Default: 1.0.
      pub speed: f32,
@@ -30,7 +30,7 @@ index 1235e6254..5c8c50eab 100644
  }
  
  impl Default for TtsOpenAiConfig {
-@@ -1357,6 +1359,7 @@ impl Default for TtsOpenAiConfig {
+@@ -1380,6 +1382,7 @@ impl Default for TtsOpenAiConfig {
              model: "tts-1".to_string(),
              format: "mp3".to_string(),
              speed: 1.0,


### PR DESCRIPTION
## What changed

- Regenerated `feature-local-stt.patch`, `feature-local-tts.patch` and `feature-local-image.patch` against current `librefang` main (`1b9518fd`).
- Bumped `pkgver` to `2026.7.27.r13.g1b9518fd1`, refreshed the three patch `sha256sums`, regenerated `.SRCINFO`.

No behaviour change: the patches carry the same `audio_base_url`, `image_base_url` and TTS `base_url` overrides as before.

## Why

`prepare()` aborted on current git:

```
-> Applying local STT, TTS and image support patches...
patching file crates/librefang-runtime-media/src/media_understanding.rs
Hunk #1 FAILED at 257.
Hunk #2 succeeded at 692 (offset 66 lines).
1 out of 2 hunks FAILED -- saving rejects to file crates/librefang-runtime-media/src/media_understanding.rs.rej
==> ERROR: A failure occurred in prepare().
```

Upstream commit `3c7fe7e4` (*feat(runtime-media): emit a failure metric for media-understanding (vision/STT)*, #6538 / #6551) wrapped both provider dispatches in

```rust
let dispatch_result: Result<String, String> = async {
    match provider { ... }
}
.await;
```

so a failure can be recorded with its provider/model before propagating. That added an indentation level to every match arm and removed the per-arm `?`. Hunk #1 of `feature-local-stt.patch` (anchored on `let transcription = match provider {`) and hunk #1 of `feature-local-image.patch` (anchored on `let description = match provider {`) no longer matched. The `image` patch failure was latent: `prepare()` died on `stt` before reaching it.

## How

The three patches are applied sequentially and overlap on `media_understanding.rs` and `media.rs`, so they were re-applied as a stacked series of commits on top of upstream `1b9518fd` and re-exported with `git diff` per layer. This keeps the same layering `prepare()` relies on.

The only substantive change is the two re-anchored hunks, now inside the `async` block:

```rust
"groq" | "openai" | "minimax" | "fireworks" | "together" | "siliconflow" => {
    let custom_url = self.config.audio_base_url.as_deref();
    let (api_url, api_key) = whisper_provider_config(provider, custom_url)?;
```

Everything else in the diff is context/offset/blob-hash churn.

## Validation

- All three patches apply with **zero fuzz and zero rejects** on a pristine checkout of `1b9518fd`.
- `cargo check -p librefang-types -p librefang-runtime-media -p librefang-runtime --all-targets` — clean.
- `cargo test -p librefang-runtime-media --lib` — 85 passed, 0 failed (includes the patch-added `openai_vision_provider_config_resolves_with_custom_url`).
- `cargo test -p librefang-types --lib` — 889 passed, 0 failed.
- `cargo test -p librefang-runtime --lib` — 2127 passed, 0 failed.
- `makepkg --verifysource` — all sums pass.
- `makepkg -f` from a clean `src/` — full build, see comment below.

## Note, not acted on here

Upstream `fab72920` (*feat(media): support custom-URL self-hosted STT/TTS providers*, #5814) has since added first-class custom-endpoint config: `[media.custom_stt]` for STT and `[tts.custom]` for TTS, selected by setting `audio_provider` / `provider` to any non-built-in name. That overlaps with what the STT and TTS patches here do, and additionally supports keyless local servers via `key_required = false`. Vision has no upstream equivalent — `describe_image` still ends in `other => Err("Unsupported image description provider")`, and the `[provider_urls]` / `MediaDriverCache` path covers image *generation*, not description.

Dropping the two patches in favour of the upstream keys would be a config-breaking change for existing users, so this PR deliberately leaves it alone and only restores the patches to a working state. Happy to open a separate PR for that if you want it.

These hunks anchor on code upstream is actively refactoring, so they will likely need re-anchoring again on future churn.