### PR TITLE
feat(amux-git): add PKGBUILD, oh-my-pi research doc and omp provider patch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ src
 .ruff-cache
 .fresh
 scratch/
+*.tar.gz
+*.tar.xz
+*.tar.zst

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,51 @@
+# Maintainer: Jules <jules@agent.local>
+
+pkgname=amux-git
+pkgver=0.1.0.r0.g0000000
+pkgrel=1
+pkgdesc="Multi-session agent orchestrator and control plane (Git version)"
+arch=('x86_64' 'aarch64')
+url="https://github.com/mixpeek/amux"
+license=('MIT')
+provides=('amux' 'amux-server')
+conflicts=('amux' 'amux-server')
+depends=('glibc' 'gcc-libs' 'openssl' 'tmux')
+makedepends=('cargo' 'git')
+options=('!lto' '!debug')
+source=("${pkgname%-git}::git+https://github.com/mixpeek/amux.git"
+        "omp-provider.patch")
+sha256sums=('SKIP'
+            'SKIP')
+
+pkgver() {
+    cd "${srcdir}/${pkgname%-git}"
+    local _ver=$(grep -m 1 '^version = ' Cargo.toml | cut -d '"' -f 2)
+    local _rev=$(git rev-parse --short HEAD)
+    local _count=$(git rev-list --count HEAD)
+    echo "${_ver}.r${_count}.g${_rev}"
+}
+
+prepare() {
+    cd "${srcdir}/${pkgname%-git}"
+    patch -Np1 -i "${srcdir}/omp-provider.patch"
+    export RUSTUP_TOOLCHAIN=stable
+    export CARGO_HOME="${srcdir}/.cargo-home"
+    cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+}
+
+build() {
+    cd "${srcdir}/${pkgname%-git}"
+    export RUSTUP_TOOLCHAIN=stable
+    export CARGO_HOME="${srcdir}/.cargo-home"
+    cargo build --release --frozen --workspace
+}
+
+package() {
+    cd "${srcdir}/${pkgname%-git}"
+    install -Dm0755 target/release/amux-server "${pkgdir}/usr/bin/amux-server"
+    install -Dm0755 target/release/amux-rs "${pkgdir}/usr/bin/amux-rs"
+    install -Dm0755 amux "${pkgdir}/usr/bin/amux"
+    install -Dm0755 amux-remote "${pkgdir}/usr/bin/amux-remote"
+    install -Dm0644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+    install -Dm0644 README.md "${pkgdir}/usr/share/doc/${pkgname}/README.md"
+}

--- a/oh-my-pi-provider.md
+++ b/oh-my-pi-provider.md
@@ -1,0 +1,65 @@
+# Oh-My-Pi (`omp`) Provider Integration Research & Plan
+
+## Overview
+This document details the research findings for integrating **oh-my-pi (`omp`)** (https://github.com/can1357/oh-my-pi) as an executing CLI provider harness in `amux`.
+
+`oh-my-pi` is an AI coding agent CLI (invoked via the binary `omp`). In `amux`, providers allow spawning interactive terminal sessions (via tmux / herdr) and headless sessions for background agent tasks.
+
+---
+
+## Codebase Architecture & Provider Integration Surface
+
+Adding a new provider `oh-my-pi` / `omp` to `amux` requires modifications across several components in `crates/amux-core` and `crates/amux-server`:
+
+### 1. `amux-core`: Domain Types & Fleet Management
+- **`crates/amux-core/src/provider.rs`**:
+  - `ProviderId`: Defines open provider identity.
+  - Document `omp` / `oh-my-pi` as a recognized provider string.
+- **`crates/amux-core/src/provider_fleet.rs`**:
+  - `ProviderFleetState`: Tracks provider health/availability in the fleet.
+  - Ensure provider ID `omp` can be registered or handled in fleet tests if applicable.
+
+### 2. `amux-server`: Provider Adapter & Registry
+- **`crates/amux-server/src/provider/static_providers.rs`**:
+  - Implement `OmpAdapter` (or `OhMyPiAdapter`) implementing `ProviderAdapter`.
+  - `id()` -> `ProviderId::new("omp")`
+  - `capabilities()` -> `ProviderCapabilities { hot_model_switch: false, reports_usage: false, structured_events: false, hooks: false }`
+  - `usage()` -> `ProviderUsage::unknown(self.id())`
+  - `models()` -> Empty or list models if `omp` supports enumeration.
+  - `build_command(prompt_mode)` -> `vec!["omp".into()]` (Interactive) or `vec!["omp".into(), "exec".into()]` / non-interactive flags.
+- **`crates/amux-server/src/provider/mod.rs`**:
+  - Register `OmpAdapter` in `default_registry()`.
+  - Add `omp` resolution alias if needed (e.g., `oh-my-pi` -> `omp`).
+  - Add conformance tests `conformance_omp()`.
+
+### 3. `amux-server`: Session Launcher & Verbs
+- **`crates/amux-server/src/api/session_verbs.rs`**:
+  - `launch_base_binary(provider)`: Return `"omp"` for provider `"omp"` (or `"oh-my-pi"`).
+  - `default_model_for_provider(provider)`: Define default model for `omp` (e.g. `"auto"` or `""`).
+  - `provider_label(provider)`: Return `"Oh-My-Pi"`.
+  - `session_verbs.rs` launch arm (`let cmd = match provider.as_str() ...`):
+    - Add `"omp" | "oh-my-pi"` arm building the launch command string for `omp` with flags and options.
+- **`crates/amux-server/src/invariants/checks.rs`**:
+  - Ensure invariant checks for launch binary matching provider adapter pass.
+
+### 4. `amux-server`: API Routes & Validation
+- **`crates/amux-server/src/api/workers.rs`** / **`crates/amux-server/src/api/lookup.rs`**:
+  - Handle worker creation and model lookups when `provider == "omp"`.
+
+---
+
+## Files to be Edited Summary
+
+1. `crates/amux-core/src/provider.rs`
+2. `crates/amux-server/src/provider/static_providers.rs`
+3. `crates/amux-server/src/provider/mod.rs`
+4. `crates/amux-server/src/api/session_verbs.rs`
+
+---
+
+## Verification & Testing Plan
+1. Edit source files in `src/amux/` using `makepkg -e` (or directly in scratch for testing).
+2. Download an `omp` binary release from `can1357/oh-my-pi`.
+3. Test `omp` execution and non-install testing on `amux-server` and `amux-rs`.
+4. Generate clean patch file and update `amux-git` PKGBUILD.
+5. Rebuild package and verify final build.

--- a/omp-provider.patch
+++ b/omp-provider.patch
@@ -1,0 +1,136 @@
+diff --git a/crates/amux-server/src/api/session_verbs.rs b/crates/amux-server/src/api/session_verbs.rs
+index 68553f3b..3ba0e69d 100644
+--- a/crates/amux-server/src/api/session_verbs.rs
++++ b/crates/amux-server/src/api/session_verbs.rs
+@@ -2423,6 +2423,7 @@ pub fn launch_base_binary(provider: &str) -> &'static str {
+     match provider {
+         // ollama runs codex under the hood (`--oss --local-provider ollama`).
+         "codex" | "ollama" => "codex",
++        "omp" | "oh-my-pi" => "omp",
+         "gemini" => "gemini",
+         // claude, iterm2, and anything unknown launch via build_claude_cmd,
+         // whose default binary is `claude` (overridable by AMUX_CLAUDE_CMD).
+@@ -2437,6 +2438,7 @@ fn provider_label(provider: &str) -> &str {
+         "gemini" => "Gemini",
+         "iterm2" => "iTerm2",
+         "ollama" => "Ollama",
++        "omp" | "oh-my-pi" => "Oh-My-Pi",
+         other => {
+             if other.is_empty() {
+                 "Claude Code"
+@@ -5316,6 +5318,16 @@ async fn start_session(state: &AppState, name: &str, extra_flags: &str, skip_con
+             }
+             format!("{base_bin}{opts}")
+         }
++        "omp" | "oh-my-pi" => {
++            let mut opts = String::new();
++            if !flags.is_empty() {
++                opts += &format!(" {}", shell_quote_flags(&flags));
++            }
++            if !extra_flags.is_empty() {
++                opts += &format!(" {}", shell_quote_flags(extra_flags));
++            }
++            format!("{base_bin}{opts}")
++        }
+         _ => build_claude_cmd(&cfg, &flags, &default_flags, &session_flag, extra_flags),
+     };
+
+@@ -5323,7 +5335,7 @@ async fn start_session(state: &AppState, name: &str, extra_flags: &str, skip_con
+     // cd, source the global agent credentials.
+     let mut has_oauth = false;
+     let mut shell_rc = String::new();
+-    if provider != "codex" && provider != "gemini" && provider != "ollama" {
++    if provider != "codex" && provider != "gemini" && provider != "ollama" && provider != "omp" && provider != "oh-my-pi" {
+         shell_rc.push_str("unset CLAUDECODE CLAUDE_CODE_ENTRYPOINT; ");
+         if let Ok(t) = std::fs::read_to_string(PathBuf::from(std::env::var("HOME").unwrap_or_default()).join(".claude.json")) {
+             if let Ok(v) = serde_json::from_str::<Value>(&t) {
+@@ -5391,7 +5403,7 @@ async fn start_session(state: &AppState, name: &str, extra_flags: &str, skip_con
+             sh_quote(&f.to_string_lossy())
+         ));
+     }
+-    if provider != "codex" && provider != "gemini" && provider != "ollama" && has_oauth {
++    if provider != "codex" && provider != "gemini" && provider != "ollama" && provider != "omp" && provider != "oh-my-pi" && has_oauth {
+         shell_rc.push_str("unset ANTHROPIC_API_KEY; ");
+     }
+     let mut env_args: Vec<String> = Vec::new();
+diff --git a/crates/amux-server/src/provider/mod.rs b/crates/amux-server/src/provider/mod.rs
+index 247be9fd..63e0b7e3 100644
+--- a/crates/amux-server/src/provider/mod.rs
++++ b/crates/amux-server/src/provider/mod.rs
+@@ -133,6 +133,7 @@ pub fn default_registry() -> ProviderRegistry {
+     reg.register(Arc::new(static_providers::GeminiAdapter));
+     reg.register(Arc::new(static_providers::CodexAdapter));
+     reg.register(Arc::new(static_providers::OllamaAdapter::default()));
++    reg.register(Arc::new(static_providers::OmpAdapter));
+     reg
+ }
+
+@@ -215,10 +216,10 @@ mod tests {
+     use super::*;
+
+     #[test]
+-    fn default_registry_registers_all_four() {
++    fn default_registry_registers_all_five() {
+         let reg = default_registry();
+-        assert_eq!(reg.len(), 4);
+-        for id in ["claude-code", "gemini", "codex", "ollama"] {
++        assert_eq!(reg.len(), 5);
++        for id in ["claude-code", "gemini", "codex", "ollama", "omp"] {
+             assert!(
+                 reg.get(&ProviderId::new(id)).is_some(),
+                 "default registry missing {id}"
+@@ -303,3 +304,8 @@ mod tests {
+         conformance_static(&claude::ClaudeAdapter::new());
+     }
+ }
++
++    #[tokio::test]
++    async fn conformance_omp() {
++        conformance(&static_providers::OmpAdapter).await;
++    }
+diff --git a/crates/amux-server/src/provider/static_providers.rs b/crates/amux-server/src/provider/static_providers.rs
+index d152baa5..946663ed 100644
+--- a/crates/amux-server/src/provider/static_providers.rs
++++ b/crates/amux-server/src/provider/static_providers.rs
+@@ -318,3 +318,41 @@ mod tests {
+         assert!(parse_ollama_list("NAME  ID  SIZE  MODIFIED\n").is_empty());
+     }
+ }
++
++// ---------------------------------------------------------------------------
++// Oh-My-Pi (omp)
++// ---------------------------------------------------------------------------
++
++/// Oh-My-Pi CLI (`omp`).
++pub struct OmpAdapter;
++
++#[async_trait]
++impl ProviderAdapter for OmpAdapter {
++    fn id(&self) -> ProviderId {
++        ProviderId::new("omp")
++    }
++
++    fn capabilities(&self) -> ProviderCapabilities {
++        ProviderCapabilities {
++            hot_model_switch: false,
++            reports_usage: false,
++            structured_events: false,
++            hooks: false,
++        }
++    }
++
++    async fn usage(&self) -> ProviderUsage {
++        ProviderUsage::unknown(self.id())
++    }
++
++    async fn models(&self) -> Vec<String> {
++        Vec::new()
++    }
++
++    fn build_command(&self, prompt_mode: PromptMode) -> Vec<String> {
++        match prompt_mode {
++            PromptMode::Interactive => vec!["omp".into()],
++            PromptMode::HeadlessStructured => vec!["omp".into(), "exec".into()],
++        }
++    }
++}


### PR DESCRIPTION
This PR adds a PKGBUILD for amux-git in the repository root, research notes for adding the oh-my-pi (omp) CLI provider harness, and a patch (omp-provider.patch) implementing the oh-my-pi provider in amux.

---
*PR created automatically by Jules for task [6062220343526812313](https://jules.google.com/task/6062220343526812313) started by @wuxxin*